### PR TITLE
add candidates find feature

### DIFF
--- a/NoteSynthesizer.py
+++ b/NoteSynthesizer.py
@@ -11,7 +11,7 @@ import librosa
 from scipy.io.wavfile import write as write_wav
 
 class NoteSynthesizer():
-    def __init__(self, dataset_path, csv_path, output_dir, sr=44100, transpose=0, attack_in_ms=5, release_in_ms=100, leg_stac=.9, velocities=np.arange(0,128), preset=0, preload=True):
+    def __init__(self, dataset_path, csv_path, output_dir, sr=44100, transpose=0, attack_in_ms=5, release_in_ms=100, leg_stac=.9, velocities=[25, 50, 75, 100, 127], preload=True):
         self.dataset_path = dataset_path
         self.midi_df = self.make_midi_df(csv_path)
         self.nsynth_df = self.make_dataframes(self.dataset_path)
@@ -26,7 +26,6 @@ class NoteSynthesizer():
         self.attack_in_sample = int(self.attack_in_ms * 0.001 * self.sr)
         self.leg_stac = leg_stac
         self.velocities = velocities
-        self.preset = preset
         self.output_dir = output_dir
 
         self.preload = preload

--- a/NoteSynthesizer.py
+++ b/NoteSynthesizer.py
@@ -3,25 +3,116 @@ import os
 import sys
 
 import numpy as np
+import pandas as pd
+import random
 
 import pretty_midi
 import librosa
 from scipy.io.wavfile import write as write_wav
 
 class NoteSynthesizer():
-    def __init__(self, dataset_path, sr=44100, transpose=0, leg_stac=.9, velocities=np.arange(0,128), preset=0, preload=True):
+    def __init__(self, dataset_path, sr=44100, transpose=0, attack_in_ms=5, release_in_ms=100, leg_stac=.9, velocities=np.arange(0,128), preset=0, preload=True):
         self.dataset_path = dataset_path
+        self.nsynth_df = self.make_dataframes(self.dataset_path)
+        self.minpitch, self.maxpitch = self._min_max_pitch(self.nsynth_df)
         self.sr = sr
         self.transpose = transpose
+        self.release_in_ms = release_in_ms
+        self.release_in_sample = int(self.release_in_ms * 0.001 * self.sr)
+        self.attack_in_ms = attack_in_ms
+        self.attack_in_sample = int(self.attack_in_ms * 0.001 * self.sr)
         self.leg_stac = leg_stac
         self.velocities = velocities
         self.preset = preset
 
         self.preload = preload
 
-    def _get_note_name(self, note, velocity, instrument, source_type, preset=None):
-        preset = preset if(preset is not None) else self.preset
-        return "%s_%s_%s-%s-%s.wav" % (instrument, source_type, str(preset).zfill(3), str(note).zfill(3), str(velocity).zfill(3))    
+        # make dataframe from json
+    def make_dataframes(self, dataset_path):
+        json_path = os.path.join(dataset_path, 'examples.json')
+        df = pd.read_json(json_path).T
+        df['preset'] = df['instrument_str'].apply(lambda x: x.split('_')[-1])
+        return df
+    
+        # get min and max pitch for each instrument
+    def _min_max_pitch(self, nsynth_df):
+        min_pitch_inst = nsynth_df.groupby('instrument_family_str').min().pitch.index.tolist()
+        min_pitch_value = nsynth_df.groupby('instrument_family_str').min().pitch.values.tolist()
+        minpitch = {inst : value for inst, value in zip(min_pitch_inst, min_pitch_value)}
+
+        max_pitch_inst = nsynth_df.groupby('instrument_family_str').max().pitch.index.tolist()
+        max_pitch_value = nsynth_df.groupby('instrument_family_str').max().pitch.values.tolist()
+        maxpitch = {inst : value for inst, value in zip(max_pitch_inst, max_pitch_value)}
+        return minpitch, maxpitch
+
+    def pop_candidates(self, candidates, currnet_candidates):
+        for i in candidates.copy().keys():
+            if (i in currnet_candidates) and (candidates[i] == currnet_candidates[i]):
+                continue
+            else:
+                candidates.pop(i)
+        return candidates
+    
+        
+    def _find_candidates(self, seq, current_inst):
+        '''
+        find preset, instrument source candidates for each note in the sequence
+
+        Input:
+            seq: list of tuples (note, velocity, start_time, end_time)
+            current_inst: seq's instrument
+        
+        Output:
+            candidates: dict of candidates {preset : instrument source}
+
+        '''
+
+        min_p = self.minpitch[current_inst]
+        max_p = self.maxpitch[current_inst]
+        nsynth_df = self.nsynth_df
+
+        candidates = {p : s for p, s in zip(nsynth_df[(nsynth_df['instrument_family_str'] == current_inst)]['preset'].values.tolist() ,
+                                                nsynth_df[(nsynth_df['instrument_family_str'] == current_inst)]['instrument_source'].values.tolist())}
+
+        for n, v, _, _ in seq:
+
+            if n < min_p or n > max_p:
+                continue
+
+            currnet_candidates = {p : s for p, s in zip(nsynth_df[(nsynth_df['instrument_family_str'] == current_inst) & 
+                                                                (nsynth_df['pitch'] == n) &
+                                                                (nsynth_df['velocity'] == v)]['preset'].values.tolist() ,
+
+                                                        nsynth_df[(nsynth_df['instrument_family_str'] == current_inst) &
+                                                                (nsynth_df['pitch'] == n) &
+                                                                (nsynth_df['velocity'] == v)]['instrument_source'].values.tolist())}
+            
+            candidates = self.pop_candidates(candidates, currnet_candidates)
+
+            if len(candidates) == 0:
+                print('No candidates')
+                return None
+
+        return candidates   
+
+    def _get_note_name_fixed(self, note, velocity, instrument, preset, source):
+
+        if source == 0:
+            source = 'acoustic'
+        elif source == 1:
+            source = 'electronic'
+        elif source == 2:
+            source = 'synthetic'
+
+        return "%s_%s_%s-%s-%s.wav" % (instrument, source, str(preset).zfill(3), str(note).zfill(3), str(velocity).zfill(3))    
+
+    def _get_note_name_random(self, note, velocity, instrument):
+        nsynth_df = self.nsynth_df
+        chosen_name = random.choice(nsynth_df[
+                                            (nsynth_df['pitch'] == note) & 
+                                            (nsynth_df['velocity'] == velocity) &
+                                            (nsynth_df['instrument_family_str'] == instrument)].index)
+        return f"{chosen_name}.wav"
 
     def _quantize(self, value, quantized_values):
         diff = np.array([np.abs(q - value) for q in quantized_values])
@@ -53,27 +144,43 @@ class NoteSynthesizer():
                     sequence.append((note.pitch, note.velocity, note.start/end_time, note.end/end_time))
         return sequence, end_time
 
-    def _render_note(self, note_filename, duration, velocity):
-        try:
-            if(self.preload):
-                note = self.notes[note_filename]
-            else:
-                note, _ = librosa.load(note_filename)
-            decay_ind = int(self.leg_stac*duration)
-            envelope = np.exp(-np.arange(len(note)-decay_ind)/3000.)
-            note[decay_ind:] = np.multiply(note[decay_ind:],envelope)
-        except:
-            print('Note not fonund', note_filename)
-            note = np.zeros(duration)
-        return note[:duration]
+    def _render_note(self, note_filename, duration):
+
+        leg_stac = self.leg_stac
+        attack_in_sample = self.attack_in_sample
+        release_in_sample = self.release_in_sample
+
+        note, _ = librosa.load(note_filename)
+        attack_env = np.arange(attack_in_sample) / attack_in_sample
+        note[:attack_in_sample] *= attack_env
+
+        decay_ind = int(leg_stac*duration)
+        envelope = np.exp(-np.arange(len(note)-decay_ind)/3000.)
+        note[decay_ind:] = np.multiply(note[decay_ind:],envelope)
+
+        release_env = (release_in_sample-np.arange(release_in_sample)) / release_in_sample
+
+        if duration + release_in_sample > len(note):
+            note[-release_in_sample:] *= release_env
+            note = np.pad(note, (0, duration + release_in_sample -len(note)), 'constant')  
+        elif duration + release_in_sample <= len(note):
+            note[duration:duration+release_in_sample] *= release_env
+
+        return note[:duration+release_in_sample]
 
     def render_sequence(self, sequence, instrument='guitar', source_type='acoustic', preset=None, playback_speed=1, duration_scale=1, transpose=0, eps=1e-9):
+        
+        dataset_path = self.dataset_path
         preset = preset if(preset is not None) else self.preset
         transpose = transpose if(transpose is not None) else self.transpose
 
         seq, end_time = self._read_midi(sequence)
         total_length = int(end_time * self.sr / playback_speed)
         data = np.zeros(total_length)
+
+        candidate = self._find_candidates(seq, instrument)
+        if candidate:
+            preset, source = random.choice(list(candidate.items()))
         
         for note, velocity, note_start, note_end in seq:
             start_sample = int(note_start * total_length)
@@ -83,24 +190,25 @@ class NoteSynthesizer():
             if(duration_scale != 1):
                 duration = int(duration * duration_scale)
                 end_sample = start_sample + duration
+
+            end_sample += self.release_in_sample
             
-            if(self.preload):
-                note_filename = self._get_note_name(
-                                                        note=note+transpose, 
-                                                        velocity=velocity, 
-                                                        instrument=instrument, 
-                                                        source_type=source_type,
-                                                        preset=preset
-                                                    )
+            if candidate == None:
+                note_filename = os.path.join(dataset_path, self._get_note_name_random(
+                                                                        note=note, 
+                                                                        velocity=velocity, 
+                                                                        instrument=instrument
+                                                                    ))
             else:
-                note_filename = os.path.join(self.dataset_path, self._get_note_name(
-                                                                            note=note+transpose, 
-                                                                            velocity=velocity, 
-                                                                            instrument=instrument, 
-                                                                            source_type=source_type,
-                                                                            preset=preset
-                                                                        ))
-            note = self._render_note(note_filename, duration, velocity)
+                note_filename = os.path.join(dataset_path, self._get_note_name_fixed(
+                                                                        note=note, 
+                                                                        velocity=velocity, 
+                                                                        instrument=instrument,
+                                                                        preset=preset,
+                                                                        source=source,
+                                                                    ))
+            
+            note = self._render_note(note_filename, duration)
 
             if(end_sample <= len(data) and duration == len(note)):
                 data[start_sample:end_sample] += note

--- a/NoteSynthesizer.py
+++ b/NoteSynthesizer.py
@@ -195,6 +195,8 @@ class NoteSynthesizer():
     def render_sequence(self, path, instrument, playback_speed=1, duration_scale=1, transpose=0, eps=1e-9, write_file=True):
         
         transpose = transpose if(transpose is not None) else self.transpose
+        preset = None
+        source = None
 
         output_dict = dict()
 
@@ -205,7 +207,6 @@ class NoteSynthesizer():
 
         instrument = inst_list[self.get_id_from_path(path)]
         split = split_list[self.get_id_from_path(path)]
-        file_name = f'{self.get_id_from_path(path)}.wav'
 
         output_dict['id'] = self.get_id_from_path(path)
         output_dict['instrument'] = instrument
@@ -223,6 +224,8 @@ class NoteSynthesizer():
             output_dict['source'] = source
 
         else:
+            preset = 'random'
+            source = 'random'
 
             output_dict['preset'] = 'random'
             output_dict['source'] = 'random'
@@ -263,6 +266,8 @@ class NoteSynthesizer():
                 data[start_sample:start_sample+len(note_audio)] += note_audio
 
         data /= np.max(np.abs(data)) + eps
+
+        file_name = f'{self.get_id_from_path(path)}_{preset}_{source}.wav'
 
         if write_file:
             write_wav(os.path.join(output_dir, 'audio', split, file_name), self.sr, np.array(32000.*data, np.short))

--- a/README.md
+++ b/README.md
@@ -47,10 +47,7 @@ from NoteSynthesizer import NoteSynthesizer
 # Create the NoteSynthesizer instance
 synth = NoteSynthesizer(path_to_nsynth, path_to_midi_csv, output_dir, sr, velocities, preload)  
 
-# Generate the audio for a given MIDI sequence
-output_dict = synth.render_sequence(sequence_path, instrument, transpose, playback_speed, duration_scale, write_wav=True)
-
-# Or you can use it with multiprocessing
+# you can use it with multiprocessing
 import billiard as mp
 from tqdm.auto import tqdm
 
@@ -69,9 +66,10 @@ with tqdm(total=total) as pbar:
 ```
 
 # Examples
-The files in the /output folder have been generated using different instruments, with sr=44100, playback_speed=1 and duration_scale=4, leaving the rest of optional parameters as default. The files are named using midi file ID.
+The files in the /output folder looks like this.
 ```bash
-<midi_name>.wav
+output_dir/audio/train/midifile01.wav, midifile02.wave
+output_dir/audio/val/midifile03.wav
 ```
 The output dictionary looks like this
 '''bash

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 # NSynth-MIDI-Renderer for massive MIDI dataset 
 
-This project is slightly modified from original work. It is designed to render large midifile datasets.
+## This project is slightly modified from original work. It is designed to render large midifile datasets.
+
+### How is it different from the original work?
+
 For a given MIDI sequence, it goes through a process of finding and assigning candidates to lock in a single preset from the beginning to the end of the sequence. 
-If it fails to find one because the combination of instrument, pitch, and velocity is unique, it will randomly use a preset for every note. 
-When tested with a 130,000 MIDI dataset, only 95 MIDI sequences were randomized, with a probability of 0.0007%.
+If it fails to find one because the combination of instrument, pitch, and velocity is unique, it will randomly use a preset for every note.
+
 
 * Original Project: https://github.com/hmartelb/NSynth-MIDI-Renderer
+
+* When tested with a 130,000 MIDI dataset, only 95 MIDI sequences were randomized, with a probability of 0.0007%.
 
 <p align="center">
 <a href="docs/NoteSynthesizer_diagram.png"><img src="docs/NoteSynthesizer_diagram.png" width="650" height="450"/></a>
@@ -66,11 +71,15 @@ with tqdm(total=total) as pbar:
 ```
 
 # Examples
+
 The files in the /output folder looks like this.
+
 ```bash
-output_dir/audio/train/midifile01.wav, midifile02.wave
+output_dir/audio/train/midifile01.wav
+output_dir/audio/train/midifile02.wav
 output_dir/audio/val/midifile03.wav
 ```
+
 The output dictionary looks like this
 
 ```python

--- a/README.md
+++ b/README.md
@@ -74,7 +74,10 @@ output_dir/audio/val/midifile03.wav
 The output dictionary looks like this
 
 ```python
-output_dict = {'id': ['midifile01', 'midifile02', 'midifile03'], 'instrument': ['keyboard', 'guitar', 'guitar'] ,'preset': ['030', '002', 'random'], 'source': [1, 0, 'random']}
+output_dict = {'id': ['midifile01', 'midifile02', 'midifile03'],
+                'instrument': ['keyboard', 'guitar', 'guitar'] ,
+                'preset': ['030', '002', 'random'],
+                'source': [1, 0, 'random']}
 ```
 
 The result of this dictionary can be used to track which presets and sources were selected for the MIDI file. 

--- a/README.md
+++ b/README.md
@@ -72,9 +72,10 @@ output_dir/audio/train/midifile01.wav, midifile02.wave
 output_dir/audio/val/midifile03.wav
 ```
 The output dictionary looks like this
-'''bash
+
+```python
 output_dict = {'id': ['midifile01', 'midifile02', 'midifile03'], 'instrument': ['keyboard', 'guitar', 'guitar'] ,'preset': ['030', '002', 'random'], 'source': [1, 0, 'random']}
-'''
+```
 
 The result of this dictionary can be used to track which presets and sources were selected for the MIDI file. 
 Information about the presets of audio sources that were subsequently used can be matched with the nsynth dataset.

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ with tqdm(total=total) as pbar:
 The files in the /output folder looks like this.
 
 ```bash
-output_dir/audio/train/midifile01.wav
-output_dir/audio/train/midifile02.wav
-output_dir/audio/val/midifile03.wav
+output_dir/audio/train/midifile01_030_1.wav
+output_dir/audio/train/midifile02_002_0.wav
+output_dir/audio/val/midifile03_random_random.wav
 ```
 
 The output dictionary looks like this

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If it fails to find one because the combination of instrument, pitch, and veloci
 # Quick start
 Clone this repository to your system.
 ```bash
-$ git clone https://github.com/spear011/NSynth-MIDI-Renderer.git
+$ git clone https://github.com/spear011/NSynth-MIDI-Renderer-for-massive-MIDI-dataset.git
 ```
 
 To start synthesizing audios, you need to download the NSynth dataset and MIDI dataset you want.

--- a/README.md
+++ b/README.md
@@ -25,10 +25,18 @@ To start synthesizing audios, you need to download the NSynth dataset and MIDI d
 For the general use case, 3 parameters must be specified:
 1)	The path to the NSynth Dataset (dir path)
 2)	csv file that containing midi file id and instrument information
-3)	The output dir path 
+3)	The output dir path
+
+## Midi Dataframe
+The dataframe containing the information in the midi dataset should look like this.
+
+|id|instrument_str|split_data|...|
+|---|---|---|---|
+|midifile01|keyboard|train|...|
+|midifile02|guitar|train|...|
+|midifile03|guitar|val|...|
 
 # Import the NoteSynthesizer Class into a Python script
-It is also possible to use the NoteSynthesizer Class in a Python script to have custom functionality. Here is a generic way to import and use it:
 
 ```python
 from NoteSynthesizer import NoteSynthesizer

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The result of this dictionary can be used to track which presets and sources wer
 Information about the presets of audio sources that were subsequently used can be matched with the nsynth dataset.
 
 # Citation
-If you use this code in your research, please cite it as below:
+If you use this code in your research, please cite both projects as below:
 ```
 @software{Martel_NSynth-MIDI-Renderer_2019,
     author = {Martel, Héctor},
@@ -102,6 +102,15 @@ If you use this code in your research, please cite it as below:
     url = {https://github.com/hmartelb/NSynth-MIDI-Renderer},
     version = {1.0.0},
     year = {2019}
+}
+
+@software{Han_NSynth-MIDI-Renderer-for-massive-MIDI-dataset_2023,
+    author = {Han, ChangHeon},
+    month = {8},
+    title = {{NSynth-MIDI-Renderer-for-massive-MIDI-dataset : NSynth synthesizer for massive midi dataset}},
+    url = {https://github.com/spear011/NSynth-MIDI-Renderer-for-massive-MIDI-dataset.git},
+    version = {1.0.0},
+    year = {2023}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,9 @@ To start synthesizing audios, you need to download the NSynth dataset and MIDI d
 
 # How to use it 
 For the general use case, 3 parameters must be specified:
-1)	The path to the NSynth Dataset (audios directory)
+1)	The path to the NSynth Dataset (dir path)
 2)	csv file that containing midi file id and instrument information
-3)	The MIDI file list (*.mid, *.midi)
-4)	The output dir path 
+3)	The output dir path 
 
 # Import the NoteSynthesizer Class into a Python script
 It is also possible to use the NoteSynthesizer Class in a Python script to have custom functionality. Here is a generic way to import and use it:

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ scipy==1.5.4
 six==1.16.0
 SoundFile==0.10.3.post1
 threadpoolctl==2.1.0
+pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ six==1.16.0
 SoundFile==0.10.3.post1
 threadpoolctl==2.1.0
 pandas
+billiard


### PR DESCRIPTION
@hmartelb 
Hi I found this code of yours really useful, thank you.
Each instrument has a different range of note pitches that can be matched with the NSynth dataset, so I've added code to filter this out.

I found that when rendering a large number of MIDI datasets, slightly unique pitches and velocities can cause different presets to be used even within a single sequence, which can degrade the quality of the audio file, so I added code to find candidates so that a single MIDI sequence can be rendered while maintaining the same preset and instrument source. If it can't find the preset and source, it will randomly select it based on the instrument, pitch, and velocity information.

During the rendering process, the release should end with the audio sample close to zero, but if it doesn't and is truncated to the length of the note, it adds click noise, so I added code to prevent that.